### PR TITLE
Build GO binary inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
+FROM golang:alpine AS build
+WORKDIR /app
+ADD . /app
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/ingress-controller ./cmd/caddy
+
 FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
-COPY ./bin/ingress-controller .
+COPY --from=build /app/bin/ingress-controller .
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE 80 443
 ENTRYPOINT ["/ingress-controller"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,21 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/ingress-controller .
 FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
+FROM golang:1.13.5 as builder
+WORKDIR /build
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+RUN mkdir -p ./bin
+COPY go.mod go.sum ./
+RUN go mod download
+COPY ./cmd ./cmd
+COPY ./pkg ./pkg
+COPY ./internal ./internal
+RUN go build -o ./bin/ingress-controller ./cmd/caddy
+
 FROM scratch
-COPY --from=build /app/bin/ingress-controller .
+COPY --from=builder /build/bin/ingress-controller .
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE 80 443
 ENTRYPOINT ["/ingress-controller"]


### PR DESCRIPTION
You can (and should) use Docker to build GO programs. With this updated `Dockerfile` you can build the binary with one simple command `docker build -t your-image-name:tag .`, then push it to your favorite registry and use it in the Helm chart.