### PR TITLE
Enable automatic HTTP -> HTTPS redirects by default

### DIFF
--- a/cmd/caddy/flag.go
+++ b/cmd/caddy/flag.go
@@ -20,6 +20,9 @@ func parseFlags() caddy.ControllerConfig {
 	var tlsUseStaging bool
 	flag.BoolVar(&tlsUseStaging, "tls-use-staging", false, "defines if the lets-encrypt staging server should be used for testing the provisioning of tls certificates.")
 
+	var automaticRedirects bool
+	flag.BoolVar(&automaticRedirects, "automatic-redirects", true, "defines if automatic HTTP -> HTTPS redirects should be enabled.")
+
 	flag.Parse()
 
 	if email == "" && enableAutomaticTLS {
@@ -28,9 +31,10 @@ func parseFlags() caddy.ControllerConfig {
 	}
 
 	return caddy.ControllerConfig{
-		Email:          email,
-		AutomaticTLS:   enableAutomaticTLS,
-		TLSUseStaging:  tlsUseStaging,
-		WatchNamespace: namespace,
+		Email:              email,
+		AutomaticTLS:       enableAutomaticTLS,
+		AutomaticRedirects: automaticRedirects,
+		TLSUseStaging:      tlsUseStaging,
+		WatchNamespace:     namespace,
 	}
 }


### PR DESCRIPTION
Fixes #11 

Add a flag `automatic-redirects` (`true` by default) that enable/disable the automatic HTTP->HTTPS redirects.

It does this by adding or not the ":80" port to the web server (if not, Caddy will automatically listen to 80 and redirects to 443.


> This branch is based on #27 so I'm keeping it a Draft until #27 is merged