### PR TITLE
docs: add the missing backslash

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Caddy Ingress Controller adhere to the following steps:
     --namespace=caddy-system \
     --repo https://caddyserver.github.io/ingress/ \
     --atomic \
-    --set image.tag=latest
+    --set image.tag=latest \
     mycaddy \
     caddy-ingress-controller
 ```


### PR DESCRIPTION
add the missing backslash in the helm install cmd  of README.md.
BTW , as there's no released version , actually the install cmd does not works (it seems helm ignores the alpha/beta/rc version by default),
should we add  `--devel` flag  temporarily to make it works until there is a released version?
just like 
```
  helm install \
    --namespace=caddy-system \
    --repo https://caddyserver.github.io/ingress/ \
    --atomic \
    --set image.tag=latest \
   --devel \
    mycaddy \
    caddy-ingress-controller
```