### PR TITLE
Allow storage adapter to overwrite a secret

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -92,7 +92,13 @@ func (s *SecretStorage) Store(key string, value []byte) error {
 		},
 	}
 
-	_, err := s.KubeClient.CoreV1().Secrets(s.Namespace).Create(&se)
+	var err error
+	if s.Exists(cleanKey(key)) {
+		_, err = s.KubeClient.CoreV1().Secrets(s.Namespace).Update(&se)
+	} else {
+		_, err = s.KubeClient.CoreV1().Secrets(s.Namespace).Create(&se)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes a bug that prevented a certificate to be updated (if outdated for example).