### PR TITLE
use caddy metrics server instead of custom one

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	_ "github.com/caddyserver/caddy/v2/modules/caddytls"
 	_ "github.com/caddyserver/caddy/v2/modules/caddytls/standardstek"
+	_ "github.com/caddyserver/caddy/v2/modules/metrics"
 )
 
 const (


### PR DESCRIPTION
Let Caddy expose metrics instead of running a background task.

I still have to add some configuration (naemly the `port` of the server)

Note that it depends on #54