### PR TITLE
Update clusterrole.yaml

### DIFF
--- a/charts/caddy-ingress-controller/Chart.yaml
+++ b/charts/caddy-ingress-controller/Chart.yaml
@@ -4,7 +4,7 @@ home: https://github.com/caddyserver/ingress
 description: A helm chart for the Caddy Kubernetes ingress controller
 icon: https://caddyserver.com/resources/images/caddy-circle-lock.svg
 type: application
-version: 0.0.1-rc2
+version: 0.0.2-rc2
 appVersion: v0.1.0
 keywords:
   - ingress-controller

--- a/charts/caddy-ingress-controller/templates/clusterrole.yaml
+++ b/charts/caddy-ingress-controller/templates/clusterrole.yaml
@@ -19,6 +19,7 @@ rules:
       - services
       - pods
       - nodes
+      - configmaps
       - routes
       - extensions
     verbs:


### PR DESCRIPTION
configmaps resource should be added in order to stop getting errors like "system:serviceaccount:caddy-ingress-controller:caddy-ingress-controller" cannot list resource "configmaps" in API group "" in the namespace "caddy-ingress-controller"