### PR TITLE
Use main branch for helm/chart-releaser-action

### DIFF
--- a/.github/workflows/helmchart-release.yml
+++ b/.github/workflows/helmchart-release.yml
@@ -17,7 +17,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@master
+        uses: helm/chart-releaser-action@main
         with:
           charts_dir: charts
         env:


### PR DESCRIPTION
It seems helm has renamed their HEAD from master to main. Update the
github workflow to reflect that.

Fixes #69