### PR TITLE
Move policy api version to stable API version

### DIFF
--- a/charts/caddy-ingress-controller/templates/poddisruptionbudget.yaml
+++ b/charts/caddy-ingress-controller/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "caddy-ingress-controller.fullname" . }}


### PR DESCRIPTION
The policy/v1beta version is deprecated and being phased out.