### PR TITLE
Fix chart test CI

### DIFF
--- a/.github/workflows/helmchart-release.yml
+++ b/.github/workflows/helmchart-release.yml
@@ -3,6 +3,9 @@ name: Release Charts
 on:
   push:
     branches: [master]
+    paths:
+      - 'charts/**'
+      - '.github/workflows/helmchart-release.yml'
 
 jobs:
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,21 +17,17 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3
         with:
           images: caddy/ingress
-          tag-sha: true
+          tags: |
+            type=semver,pattern={{raw}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -46,8 +42,8 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   lint-test:
     name: Test and lint charts
@@ -60,29 +56,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
 
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
-          fi
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
-        with:
-          version: "v0.9.0"
-        # Only build a kind cluster if there are chart changes to test.
-        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.2.0
 
       - name: Install MetalLB to allow LoadBalancer services
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           kubectl create ns metallb-system
           kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.9.3/manifests/metallb.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,16 @@ curl -H 'Host: example2.kubernetes.localhost http://127.0.0.1:80/hello2
  - You can change local port forwarded by skaffold by changing the port values in the `skaffold.yaml` file on section `portForward` `localPort`. Remind that you can forward only port greather than 1024 if you execute it as non root user
  - You can delete your local cluster with the command `kind delete cluster`
  - To use TLS your domain should be publically resolved to your cluster IP in order to allow Let's Encript to validate the domain
+
+## Releasing new helm chart version
+
+If you want to release a new version of the `caddy-ingress-controller` chart, you'll need
+to create a new PR with:
+- The new chart's `version` in `Chart.yaml`
+- The new `image.tag` in `values.yaml` (if you want to update the default image used in the chart)
+- The new `appVersion` in `Chart.yaml` (if you did the previous line)
+
+## Releasing a new app version
+
+To release a new caddy-ingress-controller image, you need to create a new semver tag.
+It will build and push an image to https://hub.docker.com/r/caddy/ingress.

--- a/charts/caddy-ingress-controller/Chart.yaml
+++ b/charts/caddy-ingress-controller/Chart.yaml
@@ -5,6 +5,7 @@ description: A helm chart for the Caddy Kubernetes ingress controller
 icon: https://caddyserver.com/resources/images/caddy-circle-lock.svg
 type: application
 version: 0.0.1-rc4
+appVersion: "0.1.0"
 keywords:
   - ingress-controller
   - caddyserver

--- a/charts/caddy-ingress-controller/values.yaml
+++ b/charts/caddy-ingress-controller/values.yaml
@@ -9,7 +9,7 @@ minikube: false
 image:
   repository: caddy/ingress
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: "v0.1.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,10 +1,3 @@
 # See https://github.com/helm/chart-testing#configuration
-remote: origin
-validate-maintainers: true
-validate-chart-schema: true
-validate-yaml: true
-check-version-increment: true
 all: true
-chart-dirs:
-  - charts
 helm-extra-args: --timeout 600s


### PR DESCRIPTION
Updated some actions and improve release workflow. New workflow would work like this:

#### When the app code changed
- Release new app version (e.g. `v0.1.1`)
- Create PR to bump app version in helm chart which also bump chart version 

#### When only the chart changed
- Update the chart version in the PR that change the chart
