### PR TITLE
Release v1.0.0 of caddy-ingress-controller chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ certificates for `test.com`.
 kubectl create secret tls mycerts --key ./tls.key --cert ./tls.crt
 ```
 
-```
-apiVersion: extensions/v1beta1
+```yaml
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example
@@ -99,13 +99,16 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: test
-          servicePort: 8080
+          service:
+            name: test
+            port:
+              number: 8080
   tls:
-  - hosts:
-    - test.com
-    secretName: mycerts # use mycerts for host test.com
+    - secretName: mycerts # use mycerts for host test.com
+      hosts:
+        - test.com
 ```
 
 ### Contribution

--- a/charts/caddy-ingress-controller/Chart.yaml
+++ b/charts/caddy-ingress-controller/Chart.yaml
@@ -4,7 +4,7 @@ home: https://github.com/caddyserver/ingress
 description: A helm chart for the Caddy Kubernetes ingress controller
 icon: https://caddyserver.com/resources/images/caddy-circle-lock.svg
 type: application
-version: 0.0.1-rc4
+version: 1.0.0
 appVersion: "0.1.0"
 keywords:
   - ingress-controller

--- a/kubernetes/sample/example-ingress.yaml
+++ b/kubernetes/sample/example-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example
@@ -10,24 +10,36 @@ spec:
     http:
       paths:
       - path: /hello1
+        pathType: Prefix
         backend:
-          serviceName: example1
-          servicePort: 8080
+          service:
+            name: example1
+            port:
+              number: 8080
       - path: /hello2
+        pathType: Prefix
         backend:
-          serviceName: example2
-          servicePort: 8080
+          service:
+            name: example2
+            port:
+              number: 8080
   - host: example2.kubernetes.localhost
     http:
       paths:
       - path: /hello1
+        pathType: Prefix
         backend:
-          serviceName: example1
-          servicePort: 8080
+          service:
+            name: example1
+            port:
+              number: 8080
       - path: /hello2
+        pathType: Prefix
         backend:
-          serviceName: example2
-          servicePort: 8080
+          service:
+            name: example2
+            port:
+              number: 8080
 #   tls:
 #   - secretName: ssl-example2.kubernetes.localhost
 #     hosts:


### PR DESCRIPTION
Helm discard <1.0.0 versions so I bumped the chart version to 1.0.0 (not the app version).

Fixes #79 
Fixes #78 
Fixes #77 
Fixes #71
Fixes #73 
Fixes #43 
