### PR TITLE
Add Backend Protocol & skip verify annotation

### DIFF
--- a/internal/caddy/ingress/annotations.go
+++ b/internal/caddy/ingress/annotations.go
@@ -7,8 +7,18 @@ const (
 	rewriteToAnnotation          = "rewrite-to"
 	rewriteStripPrefixAnnotation = "rewrite-strip-prefix"
 	disableSSLRedirect           = "disable-ssl-redirect"
+	backendProtocol              = "backend-protocol"
+	insecureSkipVerify           = "insecure-skip-verify"
 )
 
 func getAnnotation(ing *v1.Ingress, rule string) string {
 	return ing.Annotations[annotationPrefix+"/"+rule]
+}
+
+func getAnnotationBool(ing *v1.Ingress, rule string, def bool) bool {
+	val := getAnnotation(ing, rule)
+	if val == "" {
+		return def
+	}
+	return val == "true"
 }

--- a/internal/caddy/ingress/reverseproxy.go
+++ b/internal/caddy/ingress/reverseproxy.go
@@ -2,6 +2,8 @@ package ingress
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
@@ -23,13 +25,24 @@ func (p ReverseProxyPlugin) IngressPlugin() converter.PluginInfo {
 func (p ReverseProxyPlugin) IngressHandler(input converter.IngressMiddlewareInput) (*caddyhttp.Route, error) {
 	path := input.Path
 	ing := input.Ingress
+	backendProtocol := strings.ToLower(getAnnotation(ing, backendProtocol))
+
 	// TODO :-
 	// when setting the upstream url we should bypass kube-dns and get the ip address of
 	// the pod for the deployment we are proxying to so that we can proxy to that ip address port.
 	// this is good for session affinity and increases performance.
 	clusterHostName := fmt.Sprintf("%v.%v.svc.cluster.local:%d", path.Backend.Service.Name, ing.Namespace, path.Backend.Service.Port.Number)
 
+	transport := &reverseproxy.HTTPTransport{}
+
+	if backendProtocol == "https" {
+		transport.TLS = &reverseproxy.TLSConfig{
+			InsecureSkipVerify: getAnnotationBool(ing, insecureSkipVerify, true),
+		}
+	}
+
 	handler := reverseproxy.Handler{
+		TransportRaw: caddyconfig.JSONModuleObject(transport, "protocol", "http", nil),
 		Upstreams: reverseproxy.UpstreamPool{
 			{Dial: clusterHostName},
 		},


### PR DESCRIPTION
Useful if your backend application is using HTTPS (For example Unifi Network Controller). Often these apps use self-signed certificates, so caddy needs to ignore that fact.

The two annotations add the respective feature to caddy with the defaults behaving similar to nginx.