### PR TITLE
Deprecate disableSSLRedirect with sslRedirect

### DIFF
--- a/internal/caddy/ingress/annotations.go
+++ b/internal/caddy/ingress/annotations.go
@@ -4,11 +4,16 @@ import v1 "k8s.io/api/networking/v1"
 
 const (
 	annotationPrefix             = "caddy.ingress.kubernetes.io"
-	rewriteToAnnotation          = "rewrite-to"
-	rewriteStripPrefixAnnotation = "rewrite-strip-prefix"
-	disableSSLRedirect           = "disable-ssl-redirect"
 	backendProtocol              = "backend-protocol"
 	insecureSkipVerify           = "insecure-skip-verify"
+	rewriteStripPrefixAnnotation = "rewrite-strip-prefix"
+	rewriteToAnnotation          = "rewrite-to"
+	sslRedirect                  = "ssl-redirect"
+
+	//// Deprecated annotations
+
+	// Use "ssl-redirect" instead, see https://github.com/caddyserver/ingress/issues/102
+	disableSSLRedirect = "disable-ssl-redirect"
 )
 
 func getAnnotation(ing *v1.Ingress, rule string) string {
@@ -21,4 +26,9 @@ func getAnnotationBool(ing *v1.Ingress, rule string, def bool) bool {
 		return def
 	}
 	return val == "true"
+}
+
+func hasAnnotation(ing *v1.Ingress, rule string) bool {
+	_, ok := ing.Annotations[annotationPrefix+"/"+rule]
+	return ok
 }

--- a/internal/caddy/ingress/matcher.go
+++ b/internal/caddy/ingress/matcher.go
@@ -21,7 +21,11 @@ func (p MatcherPlugin) IngressPlugin() converter.PluginInfo {
 func (p MatcherPlugin) IngressHandler(input converter.IngressMiddlewareInput) (*caddyhttp.Route, error) {
 	match := caddy.ModuleMap{}
 
-	if getAnnotation(input.Ingress, disableSSLRedirect) != "true" {
+	// Ignore disable-ssl-redirect annotation if ssl-redirect is set or the disable-ssl-redirect is not set / set to false.
+	ignoreDisableSSLRedirect := hasAnnotation(input.Ingress, sslRedirect) || !getAnnotationBool(input.Ingress, disableSSLRedirect, false)
+
+	// If the disable-ssl-redirect annotation is ignored, then the ssl-redirect annotation is used.
+	if ignoreDisableSSLRedirect && getAnnotationBool(input.Ingress, sslRedirect, true) {
 		match["protocol"] = caddyconfig.JSON(caddyhttp.MatchProtocol("https"), nil)
 	}
 


### PR DESCRIPTION
For issue #102 

Should we log a deprecation notice if we detect ingress objects using the old annotation?
Could be done easily in matcher.go if we add a zap logger to the plugin.

