### PR TITLE
Added LoadBalancer annotations and LoadBalancerIP

### DIFF
--- a/charts/caddy-ingress-controller/templates/loadbalancer.yaml
+++ b/charts/caddy-ingress-controller/templates/loadbalancer.yaml
@@ -6,10 +6,15 @@ kind: Service
 metadata:
   name: {{ include "caddy-ingress-controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.loadBalancer.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "caddy-ingress-controller.labels" . | nindent 4 }}
 spec:
   type: "LoadBalancer"
+  loadBalancerIP: {{ .Values.loadBalancer.loadBalancerIP }}
   ports:
     - name: http
       port: 80

--- a/charts/caddy-ingress-controller/templates/loadbalancer.yaml
+++ b/charts/caddy-ingress-controller/templates/loadbalancer.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "caddy-ingress-controller.labels" . | nindent 4 }}
 spec:
   type: "LoadBalancer"
-  loadBalancerIP: {{ .Values.loadBalancer.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.loadBalancer.loadBalancerIP }} #Deprecated in Kubernetes v1.24
   ports:
     - name: http
       port: 80

--- a/charts/caddy-ingress-controller/values.yaml
+++ b/charts/caddy-ingress-controller/values.yaml
@@ -40,13 +40,14 @@ ingressController:
     # onDemandAsk:
 
 loadBalancer:
-  loadBalancerIP: #Deprecated in Kubernetes v1.24 
+  # Deprecated in Kubernetes v1.24
+  loadBalancerIP:
   annotations:
-    #service.beta.kubernetes.io/aws-load-balancer-type:
-    #service.beta.kubernetes.io/aws-load-balancer-nlb-target-type:
-    #service.beta.kubernetes.io/aws-load-balancer-scheme: 
-    #service.beta.kubernetes.io/aws-load-balancer-eip-allocations:
-    #service.beta.kubernetes.io/aws-load-balancer-subnets:
+    # service.beta.kubernetes.io/aws-load-balancer-type:
+    # service.beta.kubernetes.io/aws-load-balancer-nlb-target-type:
+    # service.beta.kubernetes.io/aws-load-balancer-scheme:
+    # service.beta.kubernetes.io/aws-load-balancer-eip-allocations:
+    # service.beta.kubernetes.io/aws-load-balancer-subnets:
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/caddy-ingress-controller/values.yaml
+++ b/charts/caddy-ingress-controller/values.yaml
@@ -40,7 +40,7 @@ ingressController:
     # onDemandAsk:
 
 loadBalancer:
-  loadBalancerIP:
+  loadBalancerIP: #Deprecated in Kubernetes v1.24 
   annotations:
     #service.beta.kubernetes.io/aws-load-balancer-type:
     #service.beta.kubernetes.io/aws-load-balancer-nlb-target-type:

--- a/charts/caddy-ingress-controller/values.yaml
+++ b/charts/caddy-ingress-controller/values.yaml
@@ -39,6 +39,15 @@ ingressController:
     # onDemandRateLimitBurst:
     # onDemandAsk:
 
+loadBalancer:
+  loadBalancerIP:
+  annotations:
+    #service.beta.kubernetes.io/aws-load-balancer-type:
+    #service.beta.kubernetes.io/aws-load-balancer-nlb-target-type:
+    #service.beta.kubernetes.io/aws-load-balancer-scheme: 
+    #service.beta.kubernetes.io/aws-load-balancer-eip-allocations:
+    #service.beta.kubernetes.io/aws-load-balancer-subnets:
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
This is for both issue #110 and #109 

I left some of the more common annotations required for an AWS NLB as comments. It's not as good as instructions, but it should help some people who have no idea what to put in that section.

I updated my project with this template and these additions to the values.yaml. Everything appears to be functioning as it should (the LoadbBalancerIP section is blank for me because I'm linking AWS EIPs).