### PR TITLE
Take into account that the ClusterIP can be "None"

### DIFF
--- a/internal/k8s/pod.go
+++ b/internal/k8s/pod.go
@@ -58,18 +58,18 @@ func GetAddressFromService(service *apiv1.Service) string {
 	switch service.Spec.Type {
 	case apiv1.ServiceTypeNodePort:
 	case apiv1.ServiceTypeClusterIP:
-		return service.Spec.ClusterIP
+		if service.Spec.ClusterIP != apiv1.ClusterIPNone {
+			return service.Spec.ClusterIP
+		}
 	case apiv1.ServiceTypeExternalName:
 		return service.Spec.ExternalName
 	case apiv1.ServiceTypeLoadBalancer:
-		{
-			if len(service.Status.LoadBalancer.Ingress) > 0 {
-				ingress := service.Status.LoadBalancer.Ingress[0]
-				if ingress.Hostname != "" {
-					return ingress.Hostname
-				}
-				return ingress.IP
+		if len(service.Status.LoadBalancer.Ingress) > 0 {
+			ingress := service.Status.LoadBalancer.Ingress[0]
+			if ingress.Hostname != "" {
+				return ingress.Hostname
 			}
+			return ingress.IP
 		}
 	}
 	return ""


### PR DESCRIPTION
Some services in Kubernetes can have a ClusterIP with the string "None", indicating that it is a virtual service.
For more details, see https://kubernetes.io/docs/concepts/services-networking/service/#headless-services.

This PR ensures that Caddy does not set "None" as the hostname inside the Ingress LB status.