### PR TITLE
chore(workflow): bump charts automatically when controller is released

### DIFF
--- a/.github/workflows/release-controller.yml
+++ b/.github/workflows/release-controller.yml
@@ -37,3 +37,28 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bump-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set appVersion
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.appVersion = "${{ github.ref_name }}"' 'charts/caddy-ingress-controller/Chart.yaml'
+
+      - name: Set image tag
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.image.tag = "${{ github.ref_name }}"' 'charts/caddy-ingress-controller/values.yaml'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: update-charts
+          commit-message: Update caddy-ingress charts to ${{ github.ref_name }}
+          title: Update caddy-ingress charts to ${{ github.ref_name }}
+          body: |
+            This is an automated pull request to update charts.


### PR DESCRIPTION
This pull request adds a job in `release-controller.yml` which should automatically change `appVersion` in `Charts.yml` and `image.tag` in `values.yaml` (both located in `charts/caddy-ingress-controller`).

The idea behind this is as such: When developers make changes to the controller, we release a new version. However, we don't necessarily release new versions of our charts. This changes our flow to make it easier to roll out changes in charts easier. The flow typically will look like this if this is landed:

```mermaid
graph TD
    A[Create a new release/tag]
    B[Workflow triggered by tag event]

    A-->B

    C[Package controller with GoReleaser]
    D[Update Chart.yml and values.yml]
    E[Create pull request]

    B-->C
    B-->D
    D-->E
```

**Note**: We could even update `version ` in `Charts.yml` with a patch version bump, triggering the workflow in `release-chart.yml`. Let me know if any of this would work out :)