### PR TITLE
fix: Set goarch

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ dockers:
       - "caddy/ingress:{{ .Tag }}-amd64"
     use: buildx
     dockerfile: Dockerfile
+    goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
 
@@ -32,6 +33,7 @@ dockers:
       - "caddy/ingress:{{ .Tag }}-arm64v8"
     use: buildx
     dockerfile: Dockerfile
+    goarch: arm64
     build_flag_templates:
       - "--platform=linux/arm64/v8"
 


### PR DESCRIPTION
Previously, with goarch not set, all "arm64" builds on Dockerhub actually contained an amd64 binary, preventing the ingress controller from running on arm64.