### PR TITLE
chore: enable dependabot for go packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    reviewers:
+      - "mavimo"
+      - "mholt"
+    labels:
+      - "dependencies"
+      - "dependabot"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: daily
+    reviewers:
+      - "mavimo"
+      - "mholt"
     labels:
       - "dependencies"
       - "dependabot"


### PR DESCRIPTION
## changes
 - Enable dependabot for Go deps