### PR TITLE
fix: remove parameter that is not supported in the chart-release action

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -25,6 +25,5 @@ jobs:
         uses: helm/chart-releaser-action@v1
         with:
           charts_dir: charts
-          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -22,8 +22,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1
+        uses: helm/chart-releaser-action@ed43eb303604cbc0eeec8390544f7748dc6c790d
         with:
           charts_dir: charts
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Changes
 - Remove `mark_as_latest` parameter that is not supported from the chart-release action, see [here](https://github.com/helm/chart-releaser-action/blob/v1/action.yml)