### PR TITLE
Update to go 1.21 and always use latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
+          check-latest: true
 
       - name: Test
         run: go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
@@ -42,7 +43,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
+          check-latest: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release-controller.yml
+++ b/.github/workflows/release-controller.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
+          check-latest: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/caddyserver/ingress
 
-go 1.18
+go 1.21
 
 require (
 	github.com/caddyserver/caddy/v2 v2.7.5


### PR DESCRIPTION
## Changes
 - Update to go 1.21
 - Force CI to use the last minor version available (to keep consistency with what caddy is doing [here](https://github.com/caddyserver/caddy/blob/master/.github/workflows/ci.yml#L63))