### PR TITLE
feat: Use caddy's internal Proxy protocol module

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -22,11 +22,11 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	// load required caddy plugins
+	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/proxyprotocol"
 	_ "github.com/caddyserver/caddy/v2/modules/caddyhttp/reverseproxy"
 	_ "github.com/caddyserver/caddy/v2/modules/caddytls"
 	_ "github.com/caddyserver/caddy/v2/modules/caddytls/standardstek"
 	_ "github.com/caddyserver/caddy/v2/modules/metrics"
-	_ "github.com/caddyserver/ingress/pkg/proxy"
 	_ "github.com/caddyserver/ingress/pkg/storage"
 )
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -19,6 +19,8 @@ func init() {
 
 // Wrapper provides PROXY protocol support to Caddy by implementing the caddy.ListenerWrapper interface.
 // It must be loaded before the `tls` listener.
+//
+// Deprecated: This caddy module should be replaced by the included proxy_protocol listener in Caddy.
 type Wrapper struct {
 	policy proxyproto.PolicyFunc
 }


### PR DESCRIPTION
Also deprecated the one we have as it's redundant with the one included in caddy and people should use the one provided by caddy.

Because it's the same library behind, I do not expect any breaking change.

I'll let it in draft until the new proxyprotol module is merged and released in caddy (https://github.com/caddyserver/caddy/pull/5915)