### PR TITLE
feat: exposing loadBalancer.externalTrafficPolicy value

### DIFF
--- a/charts/caddy-ingress-controller/templates/loadbalancer.yaml
+++ b/charts/caddy-ingress-controller/templates/loadbalancer.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   type: "LoadBalancer"
   loadBalancerIP: {{ .Values.loadBalancer.loadBalancerIP }} #Deprecated in Kubernetes v1.24
+  externalTrafficPolicy: {{ .Values.loadBalancer.externalTrafficPolicy }}
   ports:
     - name: http
       port: 80

--- a/charts/caddy-ingress-controller/values.yaml
+++ b/charts/caddy-ingress-controller/values.yaml
@@ -42,6 +42,8 @@ ingressController:
 loadBalancer:
   # Deprecated in Kubernetes v1.24
   loadBalancerIP:
+  # Set to 'Local' to maintain the client's IP on inbound connections
+  externalTrafficPolicy:
   annotations:
     # service.beta.kubernetes.io/aws-load-balancer-type:
     # service.beta.kubernetes.io/aws-load-balancer-nlb-target-type:


### PR DESCRIPTION
Hello Caddy team!

It is often desirable to preserve the client IP when using an ingress controller. However, to achieve this, the LoadBalancer `externalTrafficPolicy` need to be set to `Local` (see references at end of PR).

This PR proposes this: exposing the `externalTrafficPolicy` in the values.

**References**
- https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
- https://learn.microsoft.com/en-us/azure/aks/load-balancer-standard#maintain-the-clients-ip-on-inbound-connections