### PR TITLE
feat(chart): bump caddy ingress controller version

### DIFF
--- a/charts/caddy-ingress-controller/Chart.yaml
+++ b/charts/caddy-ingress-controller/Chart.yaml
@@ -4,8 +4,8 @@ home: https://github.com/caddyserver/ingress
 description: A helm chart for the Caddy Kubernetes ingress controller
 icon: https://caddyserver.com/resources/images/caddy-circle-lock.svg
 type: application
-version: 1.0.5
-appVersion: "0.1.5"
+version: 1.1.0
+appVersion: "v0.2.1"
 keywords:
   - ingress-controller
   - caddyserver

--- a/charts/caddy-ingress-controller/values.yaml
+++ b/charts/caddy-ingress-controller/values.yaml
@@ -9,7 +9,7 @@ minikube: false
 image:
   repository: caddy/ingress
   pullPolicy: IfNotPresent
-  tag: "v0.1.5"
+  tag: "v0.2.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Changes
 - Bump the ingress controller version in the chart (pending `caddy/ingress:v0.2.1` release)