### PR TITLE
fix: docker image manifest should include 'v' prefix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,11 +64,11 @@ docker_manifests:
     image_templates:
       - caddy/{{ .ProjectName }}:{{ .Tag }}-amd64
       - caddy/{{ .ProjectName }}:{{ .Tag }}-arm64v8
-  - name_template: caddy/{{ .ProjectName }}:{{ .Major }}
+  - name_template: caddy/{{ .ProjectName }}:v{{ .Major }}
     image_templates:
       - caddy/{{ .ProjectName }}:{{ .Tag }}-amd64
       - caddy/{{ .ProjectName }}:{{ .Tag }}-arm64v8
-  - name_template: caddy/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}
+  - name_template: caddy/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}
     image_templates:
       - caddy/{{ .ProjectName }}:{{ .Tag }}-amd64
       - caddy/{{ .ProjectName }}:{{ .Tag }}-arm64v8


### PR DESCRIPTION
## Changes
 - Include missing `v` prefix in docker image manifest for major and minor tags