### PR TITLE
chore: rename default branch to 'main'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Checks
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -2,7 +2,7 @@ name: Release Charts
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'charts/**'
       - '.github/workflows/release-chart.yml'


### PR DESCRIPTION
This is a PR to propose to move the default branch to `main` as GH propose for new repos:

https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch

## NB: please do  not merge until the default branch is renamed.