### PR TITLE
chore: replace depreacted function ioutil.WriteFile with os.WriteFile

### DIFF
--- a/internal/controller/action_tls.go
+++ b/internal/controller/action_tls.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -61,7 +60,7 @@ func writeFile(s *apiv1.Secret) error {
 		content = append(content, cert...)
 	}
 
-	err := ioutil.WriteFile(filepath.Join(CertFolder, s.Name+".pem"), content, 0644)
+	err := os.WriteFile(filepath.Join(CertFolder, s.Name+".pem"), content, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Replace the `ioutil.WriteFile` deprecated function, see https://pkg.go.dev/io/ioutil#WriteFile for more details.