### PR TITLE
feat(chart): add service.yaml

### DIFF
--- a/charts/caddy-ingress-controller/templates/loadbalancer.yaml
+++ b/charts/caddy-ingress-controller/templates/loadbalancer.yaml
@@ -1,6 +1,4 @@
-{{- if .Values.minikube }}
-# we don't need a loadbalancer for local deployment purposes
-{{ else }}
+{{- if .Values.loadBalancer.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,7 +12,9 @@ metadata:
     {{- include "caddy-ingress-controller.labels" . | nindent 4 }}
 spec:
   type: "LoadBalancer"
+  {{- if (semverCompare "<= 1.24-0" .Capabilities.KubeVersion.Version) }}
   loadBalancerIP: {{ .Values.loadBalancer.loadBalancerIP }} #Deprecated in Kubernetes v1.24
+  {{- end }}
   externalTrafficPolicy: {{ .Values.loadBalancer.externalTrafficPolicy }}
   ports:
     - name: http

--- a/charts/caddy-ingress-controller/templates/loadbalancer.yaml
+++ b/charts/caddy-ingress-controller/templates/loadbalancer.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- include "caddy-ingress-controller.labels" . | nindent 4 }}
 spec:
   type: "LoadBalancer"
-  {{- if (semverCompare "<= 1.24-0" .Capabilities.KubeVersion.Version) }}
+  {{- if (semverCompare "<= 1.24.0" .Capabilities.KubeVersion.Version) }}
   loadBalancerIP: {{ .Values.loadBalancer.loadBalancerIP }} #Deprecated in Kubernetes v1.24
   {{- end }}
   externalTrafficPolicy: {{ .Values.loadBalancer.externalTrafficPolicy }}

--- a/charts/caddy-ingress-controller/templates/service.yaml
+++ b/charts/caddy-ingress-controller/templates/service.yaml
@@ -1,0 +1,35 @@
+{{- if not .Values.loadBalancer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "caddy-ingress-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "caddy-ingress-controller.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+{{- if .Values.service.ipDualStack.enabled }}
+  ipFamilies: {{ toYaml .Values.service.ipDualStack.ipFamilies | nindent 4 }}
+  ipFamilyPolicy: {{ .Values.service.ipDualStack.ipFamilyPolicy }}
+{{- end }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: "{{ .Values.service.clusterIP }}"
+{{- end }}
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    {{- include "caddy-ingress-controller.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/caddy-ingress-controller/values.schema.json
+++ b/charts/caddy-ingress-controller/values.schema.json
@@ -174,6 +174,71 @@
         }
       }
     },
+    "service": {
+      "$id": "#/properties/service",
+      "type": "object",
+      "required": [
+        "type",
+        "ipDualStack"
+      ],
+      "properties": {
+        "internalTrafficPolicy": {
+          "$id": "#/properties/service/properties/internalTrafficPolicy",
+          "type": "string",
+          "enum": [
+            "Cluster",
+            "Local"
+          ]
+        },
+        "externalTrafficPolicy": {
+          "$id": "#/properties/service/properties/externalTrafficPolicy",
+          "type": "string",
+          "enum": [
+            "Cluster",
+            "Local"
+          ]
+        },
+        "annotations": {
+          "$id": "#/properties/service/properties/annotations",
+          "type": "object"
+        },
+        "type": {
+          "$id": "#/properties/service/properties/type",
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer",
+            "ExternalName"
+          ]
+        },
+        "clusterIP": {
+          "$id": "#/properties/service/properties/clusterIP",
+          "type": "string"
+        },
+        "ipDualStack": {
+          "$id": "#/properties/service/properties/name",
+          "type": "object",
+          "required": [
+            "enabled"
+          ],
+          "properties": {
+            "enabled": {
+              "$id": "#/properties/service/properties/ipDualStack/properties/enabled",
+              "type": "boolean"
+            },
+            "ipFamilies": {
+              "$id": "#/properties/service/properties/ipDualStack/properties/ipFamilies",
+              "type": "array"
+            },
+            "ipFamilyPolicy": {
+              "$id": "#/properties/service/properties/ipDualStack/properties/ipFamilyPolicy",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "serviceAccount": {
       "$id": "#/properties/serviceAccount",
       "type": "object",

--- a/charts/caddy-ingress-controller/values.schema.json
+++ b/charts/caddy-ingress-controller/values.schema.json
@@ -229,11 +229,23 @@
             },
             "ipFamilies": {
               "$id": "#/properties/service/properties/ipDualStack/properties/ipFamilies",
-              "type": "array"
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "IPv4",
+                  "IPv6"
+                ]
+              }
             },
             "ipFamilyPolicy": {
               "$id": "#/properties/service/properties/ipDualStack/properties/ipFamilyPolicy",
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "SingleStack",
+                "PreferDualStack",
+                "RequireDualStack"
+              ]
             }
           }
         }

--- a/charts/caddy-ingress-controller/values.yaml
+++ b/charts/caddy-ingress-controller/values.yaml
@@ -40,6 +40,7 @@ ingressController:
     # onDemandAsk:
 
 loadBalancer:
+  enabled: true
   # Deprecated in Kubernetes v1.24
   loadBalancerIP:
   # Set to 'Local' to maintain the client's IP on inbound connections
@@ -50,6 +51,26 @@ loadBalancer:
     # service.beta.kubernetes.io/aws-load-balancer-scheme:
     # service.beta.kubernetes.io/aws-load-balancer-eip-allocations:
     # service.beta.kubernetes.io/aws-load-balancer-subnets:
+
+service:
+  # Set to 'Local' to maintain the client's IP on inbound connections
+  externalTrafficPolicy: Cluster
+  # Enable internal traffic policy for the service
+  internalTrafficPolicy: Cluster
+  annotations: {}
+  # service.beta.kubernetes.io/aws-load-balancer-type:
+  # service.beta.kubernetes.io/aws-load-balancer-nlb-target-type:
+  # service.beta.kubernetes.io/aws-load-balancer-scheme:
+  # service.beta.kubernetes.io/aws-load-balancer-eip-allocations:
+  # service.beta.kubernetes.io/aws-load-balancer-subnets:
+  ## Service type
+  type: ClusterIP
+  ## IP address for type ClusterIP
+  clusterIP: ""
+  ipDualStack:
+    enabled: false
+    ipFamilies: ["IPv6", "IPv4"]
+    ipFamilyPolicy: "PreferDualStack"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
What problem:
I need to install caddy to K8s, but I don't need external load balancer.

Why this is a solution:
By adding this `loadBalancer.enabled` value, which default to true, we can make the load balancer optional. This is also to ensure smart transition to `service.yaml` for already-existing user of this helm chart.
