### PR TITLE
Allow running outside a cluster

### DIFF
--- a/cmd/caddy/main.go
+++ b/cmd/caddy/main.go
@@ -73,7 +73,7 @@ func main() {
 // createApiserverClient creates a new Kubernetes REST client. We assume the
 // controller runs inside Kubernetes and use the in-cluster config.
 func createApiserverClient(logger *zap.SugaredLogger) (*kubernetes.Clientset, *version.Info, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags("", "")
+	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/caddy/convert_test.go
+++ b/internal/caddy/convert_test.go
@@ -21,7 +21,7 @@ func TestConvertToCaddyConfig(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg, err := Converter{}.ConvertToCaddyConfig(store.NewStore(store.Options{}, &store.PodInfo{}))
+			cfg, err := Converter{}.ConvertToCaddyConfig(store.NewStore(store.Options{}, "", &store.PodInfo{}))
 			require.NoError(t, err)
 
 			cfgJSON, err := json.Marshal(cfg)

--- a/internal/caddy/global/secrets_store.go
+++ b/internal/caddy/global/secrets_store.go
@@ -22,7 +22,7 @@ func (p SecretsStorePlugin) GlobalHandler(config *converter.Config, store *store
 	config.Storage = converter.Storage{
 		System: "secret_store",
 		StorageValues: converter.StorageValues{
-			Namespace: store.CurrentPod.Namespace,
+			Namespace: store.ConfigNamespace,
 			LeaseID:   store.Options.LeaseID,
 		},
 	}

--- a/internal/caddy/global/tls.go
+++ b/internal/caddy/global/tls.go
@@ -40,7 +40,7 @@ func (p TLSPlugin) GlobalHandler(config *converter.Config, store *store.Store) e
 	}
 
 	if len(hosts) > 0 {
-		tlsApp.CertificatesRaw["load_folders"] = json.RawMessage(`["` + controller.CertFolder + `"]`)
+		tlsApp.CertificatesRaw["load_folders"] = json.RawMessage(`["` + controller.GetCertFolder() + `"]`)
 		// do not manage certificates for those hosts
 		httpServer.AutoHTTPS.SkipCerts = hosts
 	}

--- a/internal/caddy/global/tls_test.go
+++ b/internal/caddy/global/tls_test.go
@@ -196,7 +196,7 @@ func TestIngressTlsSkipCertificates(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			tp := TLSPlugin{}
 			c := converter.NewConfig()
-			s := store.NewStore(store.Options{}, &store.PodInfo{})
+			s := store.NewStore(store.Options{}, "", &store.PodInfo{})
 
 			for _, ing := range tC.ingresses {
 				s.AddIngress(ing)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -66,7 +67,7 @@ func (SecretStorage) CaddyModule() caddy.ModuleInfo {
 
 // Provisions the SecretStorage instance.
 func (s *SecretStorage) Provision(ctx caddy.Context) error {
-	config, _ := clientcmd.BuildConfigFromFlags("", "")
+	config, _ := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 	// creates the clientset
 	clientset, _ := kubernetes.NewForConfig(config)
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -6,19 +6,21 @@ import (
 
 // Store contains resources used to generate Caddy config
 type Store struct {
-	Options    *Options
-	ConfigMap  *ConfigMapOptions
-	Ingresses  []*v1.Ingress
-	CurrentPod *PodInfo
+	Options         *Options
+	Ingresses       []*v1.Ingress
+	ConfigMap       *ConfigMapOptions
+	ConfigNamespace string
+	CurrentPod      *PodInfo
 }
 
 // NewStore returns a new store that keeps track of K8S resources needed by the controller.
-func NewStore(opts Options, podInfo *PodInfo) *Store {
+func NewStore(opts Options, configNamespace string, podInfo *PodInfo) *Store {
 	s := &Store{
-		Options:    &opts,
-		Ingresses:  []*v1.Ingress{},
-		ConfigMap:  &ConfigMapOptions{},
-		CurrentPod: podInfo,
+		Options:         &opts,
+		Ingresses:       []*v1.Ingress{},
+		ConfigMap:       &ConfigMapOptions{},
+		ConfigNamespace: configNamespace,
+		CurrentPod:      podInfo,
 	}
 	return s
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -84,7 +84,7 @@ func TestStoreIngresses(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := NewStore(Options{}, &PodInfo{})
+			s := NewStore(Options{}, "", &PodInfo{})
 			for _, uid := range test.addIngresses {
 				i := createIngress(uid)
 				s.AddIngress(&i)
@@ -164,7 +164,7 @@ func TestStoreReturnIfHasManagedTLS(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s := NewStore(Options{}, &PodInfo{})
+			s := NewStore(Options{}, "", &PodInfo{})
 			for _, i := range test.ingresses {
 				s.AddIngress(&i)
 			}


### PR DESCRIPTION
These are some changes I made to run the controller outside of the cluster:
- Uses `KUBECONFIG` if set. Ideally, we'd also support `-kubeconfig`, because the messages logged by `BuildConfigFromFlags` allude to this.
- Allow specifying a namespace for the ConfigMap (e.g. `-config-map foo/bar`). If set, Secrets will then also be generated in this namespace, rather than the pod namespace.
- Make the `POD_{NAMESPACE,NAME}` vars optional and warn if not set. If not set, `-config-map` must be provided with an explicit namespace, and Ingress status will not list external IPs.
- Prefers `$RUNTIME_DIRECTORY/certs` over `/etc/caddy/certs`, if the env var is set. This is a variable set by systemd when setting `RuntimeDirectory` in the service configuration.
  Though I wonder if we should not just use something like `/tmp/caddy-certs` in all cases here? This works in the container, and is secure in systemd with `PrivateTmp`.

P.S.: Changes like #301 make building with distribution toolchains a bit more difficult. For example, NixOS 24.11 packages Go 1.23. This doesn't matter for standard deployments, where binaries/images are provided, of course. But if these changes sound useful, maybe we can also relax toolchain version?