### PR TITLE
Configurable cluster domain

### DIFF
--- a/cmd/caddy/flag.go
+++ b/cmd/caddy/flag.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"strings"
 
+	"github.com/caddyserver/ingress/internal/caddy/ingress"
 	"github.com/caddyserver/ingress/pkg/store"
 )
 
@@ -29,7 +30,14 @@ func parseFlags() store.Options {
 	var pluginsOrder string
 	flag.StringVar(&pluginsOrder, "plugins-order", "", "defines the order plugins should be used")
 
+	var clusterDomain string
+	flag.StringVar(&clusterDomain, "cluster-domain", "", "sets the cluster domain")
+
 	flag.Parse()
+
+	if clusterDomain != "" {
+		ingress.ClusterDomain = clusterDomain
+	}
 
 	return store.Options{
 		WatchNamespace:    namespace,

--- a/internal/caddy/ingress/reverseproxy.go
+++ b/internal/caddy/ingress/reverseproxy.go
@@ -11,6 +11,8 @@ import (
 	"github.com/caddyserver/ingress/pkg/converter"
 )
 
+var ClusterDomain = "cluster.local"
+
 type ReverseProxyPlugin struct{}
 
 func (p ReverseProxyPlugin) IngressPlugin() converter.PluginInfo {
@@ -33,7 +35,7 @@ func (p ReverseProxyPlugin) IngressHandler(input converter.IngressMiddlewareInpu
 	// when setting the upstream url we should bypass kube-dns and get the ip address of
 	// the pod for the deployment we are proxying to so that we can proxy to that ip address port.
 	// this is good for session affinity and increases performance.
-	clusterHostName := fmt.Sprintf("%v.%v.svc.cluster.local:%d", path.Backend.Service.Name, ing.Namespace, path.Backend.Service.Port.Number)
+	clusterHostName := fmt.Sprintf("%v.%v.svc.%s:%d", path.Backend.Service.Name, ing.Namespace, ClusterDomain, path.Backend.Service.Port.Number)
 
 	transport := &reverseproxy.HTTPTransport{}
 


### PR DESCRIPTION
This adds support for cluster domains other than `cluster.local`.

This feels hacky, but I didn't really find a clear path to passing some variable to ReverseProxyPlugin without introducing a global.

We can probably default this to the empty string. It should be possible to resolve e.g. `kubernetes.default.svc` inside a pod, because kubelet sets `options ndots:5` in `/etc/resolv.conf`. Making it default empty means it should work for any domain without configuration.

In my case, though, I need it to be an FQDN, because I'm running caddy-ingress outside the cluster, and my stub resolver is systemd-resolved, which has explicitely rejected support for `ndots`. (They deem it a security concern.) So I need an option like this.

Keeping the `cluster.local` default seemed like the path of least resistance, for now. 🙃