### PR TITLE
fix: wait for TLS secrets cache sync before loading certificates

### DIFF
--- a/internal/controller/action_tls.go
+++ b/internal/controller/action_tls.go
@@ -1,11 +1,13 @@
 package controller
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/caddyserver/ingress/internal/k8s"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 var certFolder = ""
@@ -117,6 +119,13 @@ func (c *CaddyController) watchTLSSecrets() error {
 
 		// Run it
 		go c.informers.TLSSecret.Run(c.stopChan)
+
+		// Wait for the TLSSecret informer to sync before loading certificates.
+		// This prevents a race condition where Caddy starts listening before
+		// certificates are written to disk.
+		if !cache.WaitForCacheSync(c.stopChan, c.informers.TLSSecret.HasSynced) {
+			return fmt.Errorf("timed out waiting for TLS secrets cache to sync")
+		}
 
 		// Sync secrets
 		secrets, err := k8s.ListTLSSecrets(params, c.resourceStore.Ingresses)


### PR DESCRIPTION
Add WaitForCacheSync for the TLSSecret informer to prevent a race condition where Caddy starts listening before TLS certificates are written to disk.

Without this fix, when the controller starts:
1. TLSSecret informer is started asynchronously
2. Caddy config is loaded (which references the cert folder)
3. Caddy starts listening on :443
4. TLS certificates are written ~100ms later

This causes SSL_PROTOCOL_ERROR for the first TLS handshakes because Caddy has no certificates loaded (cert_cache_fill: 0).

The fix ensures the TLSSecret informer has synced (and certificates are written) before watchTLSSecrets() returns, guaranteeing certs are present when Caddy loads its config.