### PR TITLE
refactor: use explicit TLS secret keys instead of map iteration

### DIFF
--- a/internal/controller/action_tls.go
+++ b/internal/controller/action_tls.go
@@ -67,11 +67,17 @@ func (c *CaddyController) onSecretDeleted(obj *apiv1.Secret) {
 }
 
 // writeFile writes a secret to a .pem file on disk.
+// The PEM file must contain the certificate before the private key.
 func writeFile(s *apiv1.Secret) error {
 	content := make([]byte, 0)
 
-	for _, cert := range s.Data {
+	// Write certificate first, then key - order matters for valid PEM.
+	// Do not iterate over s.Data map as Go maps have non-deterministic order.
+	if cert, ok := s.Data["tls.crt"]; ok {
 		content = append(content, cert...)
+	}
+	if key, ok := s.Data["tls.key"]; ok {
+		content = append(content, key...)
 	}
 
 	err := os.WriteFile(filepath.Join(GetCertFolder(), s.Name+".pem"), content, 0644)


### PR DESCRIPTION
Replace map iteration over Secret.Data with explicit access to the standard Kubernetes TLS secret keys (tls.crt, tls.key).

Benefits:
- More explicit about expected secret structure
- Follows Kubernetes TLS secret convention
- Avoids including unexpected keys if secret contains extra data
- Maintains conventional PEM order (certificate before key)

No functional change for standard TLS secrets.