### PR TITLE
Fix SecretStorage List/Stat to comply with certmagic.Storage contract

### DIFF
--- a/.github/workflows/build-ghcr.yml
+++ b/.github/workflows/build-ghcr.yml
@@ -1,0 +1,52 @@
+name: Build and Push to GHCR
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'pkg/**'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: laconicnetwork/caddy-ingress
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Build binary
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ingress-controller ./cmd/caddy
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        run: |
+          docker build \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -29,6 +29,9 @@ const (
 	leasePrefix        = "caddy-lock-"
 
 	keyPrefix = "caddy.ingress--"
+
+	// originalKeyAnnotation stores the original certmagic key on the secret.
+	originalKeyAnnotation = "certmagic.io/storage-key"
 )
 
 // matchLabels are attached to each resource so that they can be found in the future.
@@ -112,6 +115,9 @@ func (s *SecretStorage) Store(ctx context.Context, key string, value []byte) err
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   cleanKey(key, keyPrefix),
 			Labels: matchLabels,
+			Annotations: map[string]string{
+				originalKeyAnnotation: key,
+			},
 		},
 		Data: map[string][]byte{
 			"value": value,
@@ -161,21 +167,50 @@ func (s *SecretStorage) Delete(ctx context.Context, key string) error {
 
 // List returns all keys that match prefix.
 func (s *SecretStorage) List(ctx context.Context, prefix string, recursive bool) ([]string, error) {
-	var keys []string
-
 	s.logger.Debug("listing secrets", zap.String("name", prefix))
 	secrets, err := s.kubeClient.CoreV1().Secrets(s.Namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(matchLabels).String(),
 	})
 	if err != nil {
-		return keys, err
+		return nil, err
 	}
 
-	// TODO :- do we need to handle the recursive flag?
+	seen := make(map[string]bool)
+	var keys []string
+
 	for _, secret := range secrets.Items {
-		key := secret.ObjectMeta.Name
-		if strings.HasPrefix(key, cleanKey(prefix, keyPrefix)) {
-			keys = append(keys, strings.TrimPrefix(key, keyPrefix))
+		// Use the original key annotation if available (secrets created after the fix).
+		// Fall back to the cleaned key for backwards compatibility with old secrets.
+		originalKey := secret.Annotations[originalKeyAnnotation]
+		if originalKey == "" {
+			// Legacy secret without annotation - use the cleaned name.
+			// This preserves the old (buggy) behaviour for secrets that
+			// predate the fix, which is acceptable because the worst case
+			// is the same as before: mostRecentAccountEmail may fail, and
+			// certmagic will create a fresh account.
+			key := secret.ObjectMeta.Name
+			if strings.HasPrefix(key, cleanKey(prefix, keyPrefix)) {
+				keys = append(keys, strings.TrimPrefix(key, keyPrefix))
+			}
+			continue
+		}
+
+		if !strings.HasPrefix(originalKey, prefix) {
+			continue
+		}
+
+		if !recursive {
+			// Non-recursive: return only the next path component after prefix.
+			rest := strings.TrimPrefix(originalKey, prefix)
+			if idx := strings.Index(rest, "/"); idx >= 0 {
+				rest = rest[:idx]
+			}
+			originalKey = prefix + rest
+		}
+
+		if !seen[originalKey] {
+			seen[originalKey] = true
+			keys = append(keys, originalKey)
 		}
 	}
 
@@ -186,7 +221,28 @@ func (s *SecretStorage) List(ctx context.Context, prefix string, recursive bool)
 func (s *SecretStorage) Stat(ctx context.Context, key string) (certmagic.KeyInfo, error) {
 	secret, err := s.kubeClient.CoreV1().Secrets(s.Namespace).Get(context.TODO(), cleanKey(key, keyPrefix), metav1.GetOptions{})
 	if err != nil {
-		return certmagic.KeyInfo{}, err
+		// The key might be a "directory" (a prefix of real keys, not a
+		// secret itself).  Check whether any secrets exist under it.
+		if !errors.IsNotFound(err) {
+			return certmagic.KeyInfo{}, err
+		}
+		allSecrets, listErr := s.kubeClient.CoreV1().Secrets(s.Namespace).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(matchLabels).String(),
+		})
+		if listErr != nil {
+			return certmagic.KeyInfo{}, err
+		}
+		cleanedPrefix := cleanKey(key, keyPrefix)
+		for _, sec := range allSecrets.Items {
+			if strings.HasPrefix(sec.Name, cleanedPrefix+".") {
+				// At least one child exists - this is a non-terminal key.
+				return certmagic.KeyInfo{
+					Key:        key,
+					IsTerminal: false,
+				}, nil
+			}
+		}
+		return certmagic.KeyInfo{}, fs.ErrNotExist
 	}
 
 	s.logger.Debug("stats secret", zap.String("name", key))
@@ -195,7 +251,7 @@ func (s *SecretStorage) Stat(ctx context.Context, key string) (certmagic.KeyInfo
 		Key:        key,
 		Modified:   secret.GetCreationTimestamp().UTC(),
 		Size:       int64(len(secret.Data["value"])),
-		IsTerminal: false,
+		IsTerminal: true,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Fixes three bugs in `pkg/storage/storage.go` that caused ACME certificate provisioning to fail with `unable to parse email address` from Let's Encrypt when provisioning certificates for a second domain. This is the same bug reported in #63.

**Root cause:** `List()` returned K8s secret names (dot-separated) instead of original certmagic keys (slash-separated), and `Stat()` always returned `IsTerminal: false`. Together, these caused `certmagic.mostRecentAccountEmail()` to extract the entire K8s secret name as an "email address" and send it to Let's Encrypt.

## Changes

1. **`Store()`** — saves the original certmagic key as a K8s annotation (`certmagic.io/storage-key`) for later retrieval
2. **`List()`** — uses the annotation to return original keys with `/` separators; handles `recursive` flag correctly; falls back to old behavior for legacy secrets without annotations
3. **`Stat()`** — returns `IsTerminal: true` for secrets (they are files); handles "directory" prefixes by checking for child secrets; returns `fs.ErrNotExist` for unknown keys

## Test plan

- [ ] Deploy with empty ACME email and two ingress domains — both should provision certs successfully
- [ ] Verify `mostRecentAccountEmail()` returns empty string (not a mangled K8s secret name)
- [ ] Verify legacy secrets (without annotation) still work via fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)