### PR TITLE
chore: enable auto rebase strategy for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    rebase-strategy: auto
     labels:
       - "dependencies"
       - "dependabot"
@@ -11,6 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    rebase-strategy: auto
     labels:
       - "dependencies"
       - "dependabot"


### PR DESCRIPTION
## Summary

- Add `rebase-strategy: auto` to both `github-actions` and `gomod` ecosystems in `.github/dependabot.yml`
- Dependabot will now automatically rebase its open PRs when the target branch (main) is updated

## Test plan

- [ ] Merge a PR into `main` and verify Dependabot rebases its open PRs